### PR TITLE
some sift-related changes for recent ifs

### DIFF
--- a/EntireCmpUtils.py
+++ b/EntireCmpUtils.py
@@ -21,7 +21,7 @@ def unquote_u(string: str):
 
 def cmpEntireImage(ifs_img, d, portalinfo):
     ks, des = sift.detectAndCompute(ifs_img, None)
-    matches = flann.knnMatch(des, d, k=2)
+    matches = flann.knnMatch(d.astype("float32"), des.astype("float32"), k=2)
     matches_len = len(matches)
 
     print("IFS Total Keys: " + str(len(ks)))
@@ -31,8 +31,10 @@ def cmpEntireImage(ifs_img, d, portalinfo):
 
     store_im = ifs_img.copy()
     for mt in matches:
-        kpit = ks[mt.trainIdx]
-        cv2.circle(store_im, tuple(map(int, kpit.pt)), 2, (0, 0, 255), 4)
+        kpit0 = ks[mt[0].trainIdx]
+        kpit1 = ks[mt[1].trainIdx]
+        cv2.circle(store_im, tuple(map(int, kpit0.pt)), 2, (0, 0, 255), 4)
+        #cv2.circle(store_im, tuple(map(int, kpit1.pt)), 2, (0, 255, 0), 4)
     cv2.imwrite("cmp/" + unquote_u(portalinfo["Name"]) + ".jpg", store_im)
     return True
 

--- a/EntireCmpUtils.py
+++ b/EntireCmpUtils.py
@@ -34,7 +34,7 @@ def cmpEntireImage(ifs_img, d, portalinfo):
         kpit = ks[mt.trainIdx]
         cv2.circle(store_im, tuple(map(int, kpit.pt)), 2, (0, 0, 255), 4)
     cv2.imwrite("cmp/" + unquote_u(portalinfo["Name"]) + ".jpg", store_im)
-    return true
+    return True
 
 
 def get_sift_features(pid):

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ def main_download():
     return portal_list
 
 
-def main_features(portal_list, sift=False):
+def main_features(portal_list, sift=True):
     print("[IFSolver] Getting Features")
     dlist = []
     for portal in portal_list:


### PR DESCRIPTION
This PR enables SIFT for changes of recent IFS puzzles and fixes some bugs
开了SIFT, 捉了些虫. 
关于如何验证有效匹配靠查理羊了, 猫猫就溜了

Need review by Charles Yang @YukariChiba 

---

d2a9575  fix the incoming error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/camber/IFSolver/main.py", line 101, in main
    main_cmp(img, portal_list, dlist)
  File "/home/camber/IFSolver/main.py", line 86, in main_cmp
    res = cmpEntireImage(
  File "/home/camber/IFSolver/EntireCmpUtils.py", line 24, in cmpEntireImage
    matches = flann.knnMatch(des, d, k=2)
cv2.error: OpenCV(4.5.2) /build/opencv/src/opencv-4.5.2/modules/flann/src/miniflann.cpp:336: error: (-210:Unsupported format or combination of formats) in function 'buildIndex_'
> type=0
> 
```
Reference: https://stackoverflow.com/questions/55861454/replacing-sift-with-brisk-is-opencv-causing-error/55864428